### PR TITLE
Add sector performance summary to holdings view

### DIFF
--- a/bhav_fetch.py
+++ b/bhav_fetch.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+import csv
+import datetime as dt
+import time
+from urllib.parse import quote
+import requests
+
+# -------- Config --------
+SYMBOL = "M&M"          # change to your symbol (e.g., RELIANCE, TCS, HDFCBANK, etc.)
+SERIES = '["EQ"]'       # common delivery series for equities
+YEARS = 1              # how many years back
+CHUNK_DAYS = 180        # query window; reduce if you hit 413/429/5xx
+OUT_CSV = f"{SYMBOL.replace('/', '_').replace('&','and')}_NSE_10y.csv"
+BASE = "https://www.nseindia.com"
+HIST_URL = BASE + "/api/historical/cm/equity"
+
+# -------- Helpers --------
+def ddmmyyyy(d: dt.date) -> str:
+    return d.strftime("%d-%m-%Y")
+
+def fetch_chunk(sess: requests.Session, symbol: str, d1: dt.date, d2: dt.date):
+    """
+    Returns list of dict rows for [d1, d2] inclusive.
+    """
+    params = {
+        "symbol": symbol,
+        "series": SERIES,
+        "from": ddmmyyyy(d1),
+        "to": ddmmyyyy(d2),
+    }
+    # NSE blocks “non-browsery” requests; set UA + Referer and keep cookies.
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+        "Referer": f"{BASE}/get-quotes/equity?symbol={quote(symbol, safe='')}",
+        "Accept": "application/json,text/plain,*/*",
+    }
+    r = sess.get(HIST_URL, params=params, headers=headers, timeout=30)
+    r.raise_for_status()
+    data = r.json()
+    # The payload usually has a 'data' list with day rows.
+    return data.get("data", []) if isinstance(data, dict) else data
+
+def ensure_session() -> requests.Session:
+    sess = requests.Session()
+    # Hit homepage once to obtain cookies/route — improves odds of 200 vs 403.
+    sess.headers.update({"User-Agent": "Mozilla/5.0"})
+    sess.get(BASE, timeout=30)
+    return sess
+
+# -------- Main --------
+def main():
+    today = dt.date.today()
+    start = today.replace(year=today.year - YEARS)
+    sess = ensure_session()
+
+    all_rows = []
+    d1 = start
+    while d1 <= today:
+        d2 = min(d1 + dt.timedelta(days=CHUNK_DAYS - 1), today)
+        try:
+            rows = fetch_chunk(sess, SYMBOL, d1, d2)
+            # Append in chronological order; API may return newest-first
+            for row in rows:
+                all_rows.append(row)
+            # polite pause
+            time.sleep(0.6)
+        except requests.HTTPError as e:
+            print(f"[WARN] {d1}..{d2}: HTTP error: {e}")
+        except Exception as e:
+            print(f"[WARN] {d1}..{d2}: {e}")
+        d1 = d2 + dt.timedelta(days=1)
+
+    if not all_rows:
+        print("No data returned. Try reducing CHUNK_DAYS or check symbol/series.")
+        return
+
+    # Normalize columns commonly present in this endpoint
+    # Typical keys: 'CH_TIMESTAMP','CH_OPENING_PRICE','CH_TRADE_HIGH_PRICE','CH_TRADE_LOW_PRICE',
+    # 'CH_CLOSING_PRICE','CH_PREVIOUS_CLS_PRICE','CH_TOT_TRADED_QTY','CH_TOT_TRADED_VAL','CH_52WEEK_HIGH_PRICE','CH_52WEEK_LOW_PRICE'
+    # (Exact fields can vary; we write what we see across rows.)
+    # Build a unified header
+    header = set()
+    for r in all_rows:
+        header.update(r.keys())
+    header = sorted(header)
+
+    # Sort by date if timestamp column exists
+    def parse_date(x):
+        v = x.get("CH_TIMESTAMP") or x.get("timestamp") or ""
+        try:
+            # CH_TIMESTAMP usually DD-MMM-YYYY (e.g., 08-Oct-2025); fall back if needed
+            return dt.datetime.strptime(v, "%d-%b-%Y")
+        except Exception:
+            try:
+                return dt.datetime.strptime(v, "%d-%m-%Y")
+            except Exception:
+                return dt.datetime.min
+
+    all_rows.sort(key=parse_date)
+
+    with open(OUT_CSV, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+        w.writerows(all_rows)
+
+    print(f"Wrote {len(all_rows)} rows to {OUT_CSV}")
+
+if __name__ == "__main__":
+    main()

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -25,11 +25,22 @@ def api_holdings() -> Dict[str, Any]:
     try:
         df = holdings_reader.load_holdings_df()
         df = frontend_parser.compute_frontend_table(df)
+        sector_df = frontend_parser.compute_sector_performance(df)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     data: List[Dict[str, Any]] = df.to_dict(orient="records")  # pyright: ignore[reportAssignmentType, reportReturnType]
-    return JSONResponse(content={"columns": list(df.columns), "rows": data}) # pyright: ignore[reportReturnType]
+    sector_data: List[Dict[str, Any]] = sector_df.to_dict(orient="records")  # pyright: ignore[reportAssignmentType]
+    return JSONResponse(
+        content={
+            "columns": list(df.columns),
+            "rows": data,
+            "sector_summary": {
+                "columns": list(sector_df.columns),
+                "rows": sector_data,
+            },
+        }
+    )  # pyright: ignore[reportReturnType]
 
 
 @app.get("/holdings", response_class=HTMLResponse)
@@ -38,6 +49,7 @@ def html_holdings(request: Request):
     try:
         df = holdings_reader.load_holdings_df()
         df = frontend_parser.compute_frontend_table(df)
+        sector_df = frontend_parser.compute_sector_performance(df)
         # Best-effort: show the specific file used
         try:
             reports_dir = Path(holdings_reader.os.getenv("REPORTS_DIR") or "Reports")
@@ -52,6 +64,8 @@ def html_holdings(request: Request):
                 "request": request,
                 "columns": list(df.columns),
                 "rows": df.to_dict(orient="records"),
+                "sector_columns": list(sector_df.columns),
+                "sector_rows": sector_df.to_dict(orient="records"),
                 "source": source,
                 "error": None,
             },
@@ -64,6 +78,8 @@ def html_holdings(request: Request):
                 "request": request,
                 "columns": [],
                 "rows": [],
+                "sector_columns": [],
+                "sector_rows": [],
                 "source": source,
                 "error": str(exc),
             },

--- a/frontend_parser.py
+++ b/frontend_parser.py
@@ -72,3 +72,59 @@ def compute_frontend_table(df: pd.DataFrame) -> pd.DataFrame:
     out["PNL%"] = pnlpct.round(0).astype(int).astype(str) + "%"
 
     return out
+
+
+def compute_sector_performance(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate holdings into a sector-level performance table."""
+
+    required = [
+        "Sector",
+        "Investment Value",
+        "Present Value",
+        "Net Pnl",
+    ]
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(
+            "Missing required columns for sector performance aggregation: "
+            f"{missing}"
+        )
+
+    if df.empty:
+        return pd.DataFrame(columns=[
+            "Sector",
+            "Investment Value",
+            "Present Value",
+            "Net Pnl",
+            "Net Performance %",
+        ])
+
+    work = df.copy()
+    work["Sector"] = work["Sector"].replace({"": "Unspecified"}).fillna("Unspecified")
+
+    inv = pd.to_numeric(work["Investment Value"], errors="coerce").fillna(0.0)
+    present = pd.to_numeric(work["Present Value"], errors="coerce").fillna(0.0)
+    pnl = pd.to_numeric(work["Net Pnl"], errors="coerce").fillna(0.0)
+
+    work["Investment Value"] = inv
+    work["Present Value"] = present
+    work["Net Pnl"] = pnl
+
+    sector = (
+        work.groupby("Sector", dropna=False)[["Investment Value", "Present Value", "Net Pnl"]]
+        .sum()
+        .reset_index()
+    )
+
+    # Weighted average net performance based on investment value
+    performance = sector["Net Pnl"] / sector["Investment Value"].replace({0.0: pd.NA})
+    performance = performance.fillna(0.0) * 100
+
+    sector["Investment Value"] = sector["Investment Value"].round(2)
+    sector["Present Value"] = sector["Present Value"].round(2)
+    sector["Net Pnl"] = sector["Net Pnl"].round(2)
+    sector["Net Performance %"] = performance.round(2)
+
+    sector = sector.sort_values(by="Investment Value", ascending=False).reset_index(drop=True)
+
+    return sector

--- a/frontend_parser.py
+++ b/frontend_parser.py
@@ -75,7 +75,10 @@ def compute_frontend_table(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def compute_sector_performance(df: pd.DataFrame) -> pd.DataFrame:
-    """Aggregate holdings into a sector-level performance table."""
+    """Aggregate holdings into a sector-level performance table.
+
+    Adds a "Stocks" column indicating the number of distinct symbols in each sector.
+    """
 
     required = [
         "Sector",
@@ -93,6 +96,7 @@ def compute_sector_performance(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
         return pd.DataFrame(columns=[
             "Sector",
+            "Stocks",
             "Investment Value",
             "Present Value",
             "Net Pnl",
@@ -110,11 +114,20 @@ def compute_sector_performance(df: pd.DataFrame) -> pd.DataFrame:
     work["Present Value"] = present
     work["Net Pnl"] = pnl
 
+    # Aggregate sums
     sector = (
         work.groupby("Sector", dropna=False)[["Investment Value", "Present Value", "Net Pnl"]]
         .sum()
         .reset_index()
     )
+
+    # Count distinct symbols per sector
+    stocks = (
+        work.groupby("Sector", dropna=False)["Symbol"].nunique().rename("Stocks").reset_index()
+    )
+
+    # Merge counts
+    sector = sector.merge(stocks, on="Sector", how="left")
 
     # Weighted average net performance based on investment value
     performance = sector["Net Pnl"] / sector["Investment Value"].replace({0.0: pd.NA})
@@ -124,6 +137,17 @@ def compute_sector_performance(df: pd.DataFrame) -> pd.DataFrame:
     sector["Present Value"] = sector["Present Value"].round(2)
     sector["Net Pnl"] = sector["Net Pnl"].round(2)
     sector["Net Performance %"] = performance.round(2)
+
+    # Reorder columns for display
+    desired_cols = [
+        "Sector",
+        "Stocks",
+        "Investment Value",
+        "Present Value",
+        "Net Pnl",
+        "Net Performance %",
+    ]
+    sector = sector[desired_cols]
 
     sector = sector.sort_values(by="Investment Value", ascending=False).reset_index(drop=True)
 

--- a/templates/holdings.html
+++ b/templates/holdings.html
@@ -10,7 +10,7 @@
     h1 { margin: 0 0 8px; font-size: 20px; }
     h2 { margin: 24px 0 8px; font-size: 17px; }
     .meta { margin: 4px 0 16px; color: var(--muted); font-size: 13px; }
-    .actions { margin-bottom: 12px; }
+    .actions { margin-bottom: 12px; position: fixed; top: 12px; right: 16px; z-index: 10; }
     .actions a { text-decoration: none; color: #0b5fff; }
     .error { background: #fff4f4; border: 1px solid #ffb4b4; color: #7a0000; padding: 10px; border-radius: 6px; margin: 12px 0; }
     table { border-collapse: collapse; width: 100%; }
@@ -18,6 +18,8 @@
     th { background: #f6f6f6; text-align: left; position: sticky; top: 0; }
     tbody tr:nth-child(even) { background: var(--stripe); }
     .scroll { overflow: auto; max-height: 80vh; border: 1px solid var(--bd); border-radius: 6px; }
+    /* Limit sector table to ~10 rows (incl. header) */
+    .sector-scroll { max-height: 300px; }
     .empty { color: var(--muted); font-style: italic; padding: 8px 0; }
     /* Net PnL shading */
     td.pnl.pos { background: #e6ffed; }
@@ -31,15 +33,59 @@
   <meta http-equiv="Expires" content="0" />
 </head>
 <body>
-  <h1>Current Holdings</h1>
+  <h1>Protfolio Overview</h1>
   <div class="meta">Source: {{ source }}</div>
   <div class="actions"><a href="/holdings">Refresh</a> | <a href="/api/holdings" target="_blank" rel="noreferrer">View JSON</a></div>
+  {% if sector_columns and sector_rows %}
+    <h2>Sector Performance</h2>
+    <div class="meta">Net performance weighted by investment value.</div>
+    <div class="scroll sector-scroll">
+      <table data-sortable="true">
+        <thead>
+          <tr>
+            {% for c in sector_columns %}
+              <th class="sortable" data-col="{{ loop.index0 }}" title="Sort">{{ c }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in sector_rows %}
+            <tr>
+              {% for c in sector_columns %}
+                {% set v = row.get(c) %}
+                {% set cls = '' %}
+                {% if c == 'Net Pnl' %}
+                  {% if v is number and v > 0 %}{% set cls = 'pnl pos' %}{% elif v is number and v < 0 %}{% set cls = 'pnl neg' %}{% else %}{% set cls = 'pnl zero' %}{% endif %}
+                {% endif %}
+                <td class="{{ cls }}">
+                  {% if v is number %}
+                    {% if c == 'Stocks' %}
+                      {{ '%.0f'|format(v) }}
+                    {% elif c.endswith('%') %}
+                      {{ '%.2f%%'|format(v) }}
+                    {% else %}
+                      {{ '%.2f'|format(v) }}
+                    {% endif %}
+                  {% else %}
+                    {{ v }}
+                  {% endif %}
+                </td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+
+  
 
   {% if error %}
     <div class="error">{{ error }}</div>
   {% endif %}
 
   {% if columns and rows %}
+    <h2>Current Holdings</h2>
     <div class="scroll">
       <table data-sortable="true">
         <thead>
@@ -79,45 +125,6 @@
     <div class="empty">No holdings to display.</div>
   {% endif %}
 
-  {% if sector_columns and sector_rows %}
-    <h2>Sector Performance</h2>
-    <div class="meta">Net performance weighted by investment value.</div>
-    <div class="scroll">
-      <table data-sortable="true">
-        <thead>
-          <tr>
-            {% for c in sector_columns %}
-              <th class="sortable" data-col="{{ loop.index0 }}" title="Sort">{{ c }}</th>
-            {% endfor %}
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in sector_rows %}
-            <tr>
-              {% for c in sector_columns %}
-                {% set v = row.get(c) %}
-                {% set cls = '' %}
-                {% if c == 'Net Pnl' %}
-                  {% if v is number and v > 0 %}{% set cls = 'pnl pos' %}{% elif v is number and v < 0 %}{% set cls = 'pnl neg' %}{% else %}{% set cls = 'pnl zero' %}{% endif %}
-                {% endif %}
-                <td class="{{ cls }}">
-                  {% if v is number %}
-                    {% if c.endswith('%') %}
-                      {{ '%.2f%%'|format(v) }}
-                    {% else %}
-                      {{ '%.2f'|format(v) }}
-                    {% endif %}
-                  {% else %}
-                    {{ v }}
-                  {% endif %}
-                </td>
-              {% endfor %}
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% endif %}
   <script>
     (function () {
       const getCell = (tr, idx) => tr.children[idx]?.textContent?.trim() ?? '';

--- a/templates/holdings.html
+++ b/templates/holdings.html
@@ -8,6 +8,7 @@
     :root { --bg: #ffffff; --fg: #111; --muted: #666; --bd: #ddd; --stripe: #fafafa; }
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; padding: 16px; color: var(--fg); background: var(--bg); }
     h1 { margin: 0 0 8px; font-size: 20px; }
+    h2 { margin: 24px 0 8px; font-size: 17px; }
     .meta { margin: 4px 0 16px; color: var(--muted); font-size: 13px; }
     .actions { margin-bottom: 12px; }
     .actions a { text-decoration: none; color: #0b5fff; }
@@ -40,7 +41,7 @@
 
   {% if columns and rows %}
     <div class="scroll">
-      <table>
+      <table data-sortable="true">
         <thead>
           <tr>
             {% for c in columns %}
@@ -48,7 +49,7 @@
             {% endfor %}
           </tr>
         </thead>
-        <tbody id="rows">
+        <tbody>
           {% for row in rows %}
             <tr>
               {% for c in columns %}
@@ -57,7 +58,17 @@
                 {% if c == 'Net Pnl' %}
                   {% if v is number and v > 0 %}{% set cls = 'pnl pos' %}{% elif v is number and v < 0 %}{% set cls = 'pnl neg' %}{% else %}{% set cls = 'pnl zero' %}{% endif %}
                 {% endif %}
-                <td class="{{ cls }}">{% if v is number %}{{ '%.2f'|format(v) }}{% else %}{{ v }}{% endif %}</td>
+                <td class="{{ cls }}">
+                  {% if v is number %}
+                    {% if c.endswith('%') %}
+                      {{ '%.2f%%'|format(v) }}
+                    {% else %}
+                      {{ '%.2f'|format(v) }}
+                    {% endif %}
+                  {% else %}
+                    {{ v }}
+                  {% endif %}
+                </td>
               {% endfor %}
             </tr>
           {% endfor %}
@@ -67,17 +78,51 @@
   {% else %}
     <div class="empty">No holdings to display.</div>
   {% endif %}
+
+  {% if sector_columns and sector_rows %}
+    <h2>Sector Performance</h2>
+    <div class="meta">Net performance weighted by investment value.</div>
+    <div class="scroll">
+      <table data-sortable="true">
+        <thead>
+          <tr>
+            {% for c in sector_columns %}
+              <th class="sortable" data-col="{{ loop.index0 }}" title="Sort">{{ c }}</th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in sector_rows %}
+            <tr>
+              {% for c in sector_columns %}
+                {% set v = row.get(c) %}
+                {% set cls = '' %}
+                {% if c == 'Net Pnl' %}
+                  {% if v is number and v > 0 %}{% set cls = 'pnl pos' %}{% elif v is number and v < 0 %}{% set cls = 'pnl neg' %}{% else %}{% set cls = 'pnl zero' %}{% endif %}
+                {% endif %}
+                <td class="{{ cls }}">
+                  {% if v is number %}
+                    {% if c.endswith('%') %}
+                      {{ '%.2f%%'|format(v) }}
+                    {% else %}
+                      {{ '%.2f'|format(v) }}
+                    {% endif %}
+                  {% else %}
+                    {{ v }}
+                  {% endif %}
+                </td>
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
   <script>
     (function () {
-      const table = document.querySelector('table');
-      if (!table) return;
-      const tbody = document.getElementById('rows');
-      if (!tbody) return;
-      const ths = table.querySelectorAll('th.sortable');
       const getCell = (tr, idx) => tr.children[idx]?.textContent?.trim() ?? '';
       const asNumber = (s) => {
         if (!s) return NaN;
-        // Remove common thousand separators and currency symbols
         const t = s.replace(/[,₹$%]/g, '');
         const n = Number(t);
         return Number.isNaN(n) ? NaN : n;
@@ -86,34 +131,40 @@
         const ts = Date.parse(s);
         return Number.isNaN(ts) ? null : ts;
       };
-      let lastCol = -1, lastDir = 1;
-      ths.forEach((th) => {
-        th.style.cursor = 'pointer';
-        th.addEventListener('click', () => {
-          const col = Number(th.dataset.col || 0);
-          let dir = 1;
-          if (col === lastCol) dir = -lastDir; // toggle
-          lastCol = col; lastDir = dir;
 
-          const rows = Array.from(tbody.querySelectorAll('tr'));
-          rows.sort((a, b) => {
-            const av = getCell(a, col);
-            const bv = getCell(b, col);
-            // Prefer numeric
-            const an = asNumber(av), bn = asNumber(bv);
-            if (!Number.isNaN(an) && !Number.isNaN(bn)) {
-              return dir * (an - bn);
-            }
-            // Try date
-            const ad = asDate(av), bd = asDate(bv);
-            if (ad !== null && bd !== null) {
-              return dir * (ad - bd);
-            }
-            // Fallback string compare
-            return dir * av.localeCompare(bv, undefined, { sensitivity: 'base' });
+      document.querySelectorAll('table[data-sortable="true"]').forEach((table) => {
+        const tbody = table.tBodies[0];
+        if (!tbody) return;
+        const ths = table.querySelectorAll('th.sortable');
+        let lastCol = -1;
+        let lastDir = 1;
+        ths.forEach((th) => {
+          th.style.cursor = 'pointer';
+          th.addEventListener('click', () => {
+            const col = Number(th.dataset.col || 0);
+            let dir = 1;
+            if (col === lastCol) dir = -lastDir;
+            lastCol = col;
+            lastDir = dir;
+
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            rows.sort((a, b) => {
+              const av = getCell(a, col);
+              const bv = getCell(b, col);
+              const an = asNumber(av);
+              const bn = asNumber(bv);
+              if (!Number.isNaN(an) && !Number.isNaN(bn)) {
+                return dir * (an - bn);
+              }
+              const ad = asDate(av);
+              const bd = asDate(bv);
+              if (ad !== null && bd !== null) {
+                return dir * (ad - bd);
+              }
+              return dir * av.localeCompare(bv, undefined, { sensitivity: 'base' });
+            });
+            rows.forEach((r) => tbody.appendChild(r));
           });
-          // Re-attach in new order
-          rows.forEach((r) => tbody.appendChild(r));
         });
       });
     })();


### PR DESCRIPTION
## Summary
- compute sector-level investment, value, and weighted performance from the holdings table
- expose the sector summary to both the JSON API response and the HTML template
- render a sortable sector performance table alongside holdings details in the UI

## Testing
- python -m compileall fastapi_app.py frontend_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68e420b482148324abc533db474281af